### PR TITLE
Further optimizations and improvements for JsonReader.

### DIFF
--- a/src/JsonIgnoreAttribute.cs
+++ b/src/JsonIgnoreAttribute.cs
@@ -6,7 +6,7 @@ namespace Maverick.Json
     /// Instructs the <see cref="JsonSettings"/> not to serialize the public field or public read/write property value.
     /// </summary>
     [AttributeUsage( AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false )]
-    public sealed class JsonIgnoreAttribute : Attribute
+    public class JsonIgnoreAttribute : Attribute
     {
     }
 }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -27,6 +27,12 @@ namespace Maverick.Json
         }
 
 
+        /// <summary>
+        /// User defined object state that can be used by application.
+        /// </summary>
+        public Object State { get; set; }
+
+
         public JsonSettings Settings { get; }
 
 
@@ -371,7 +377,7 @@ namespace Maverick.Json
         public unsafe Char ReadChar()
         {
             CheckToken( JsonToken.String );
-            var byteCount = ReadEscapedStringByteCount( Constants.MaxCharSize, out var escapeByteCount, out var continuous );
+            var byteCount = ReadEscapedStringByteCount( Constants.MaxCharSize, out var escapeByteCount, out var _ );
 
             if ( byteCount == 0 )
             {
@@ -381,7 +387,7 @@ namespace Maverick.Json
             Span<Byte> bytes = stackalloc Byte[ byteCount ];
             CopySpan( bytes );
 
-            var resultChar = default( Char );
+            Char resultChar;
 
             if ( bytes[ 0 ] == (Byte)'\\' )
             {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -36,7 +36,7 @@ namespace Maverick.Json
             {
                 m_currentToken = PeekCore();
 
-                if ( m_expectComma )
+                if ( m_expectComma && m_currentToken != JsonToken.None )
                 {
                     JsonSerializationException.ThrowMissingComma( m_currentToken );
                 }
@@ -97,13 +97,13 @@ namespace Maverick.Json
             void SkipNumber()
             {
                 var byteCount = ReadValueByteCount( Constants.MaxFloatSize, out var _ );
-                CompleteReadToken( JsonToken.Number, byteCount );
+                CompleteReadValueToken( byteCount );
             }
 
             void SkipString()
             {
                 var byteCount = ReadStringByteCount( Int32.MaxValue, out var _, out var _ );
-                CompleteReadToken( JsonToken.String, byteCount + 1 );
+                CompleteReadValueToken( byteCount + 1 );
             }
         }
 
@@ -308,7 +308,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( Int64 ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.Number, buffer.Length );
+            CompleteReadValueToken( buffer.Length );
 
             return value;
         }
@@ -351,7 +351,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( UInt64 ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.Number, buffer.Length );
+            CompleteReadValueToken( buffer.Length );
 
             return value;
         }
@@ -424,7 +424,7 @@ namespace Maverick.Json
             resultChar = result[ 0 ];
 
         Complete:
-            CompleteReadToken( JsonToken.String, byteCount + 1 );
+            CompleteReadValueToken( byteCount + 1 );
 
             return resultChar;
         }
@@ -450,7 +450,7 @@ namespace Maverick.Json
 
             if ( byteCount == 0 )
             {
-                CompleteReadToken( JsonToken.String, 1 );
+                CompleteReadValueToken( 1 );
                 return String.Empty;
             }
 
@@ -491,7 +491,7 @@ namespace Maverick.Json
                 result = UnescapeString( buffer, escapeByteCount );
             }
 
-            CompleteReadToken( JsonToken.String, buffer.Length + 1 );
+            CompleteReadValueToken( buffer.Length + 1 );
 
             return result;
         }
@@ -539,7 +539,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( Single ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.Number, buffer.Length );
+            CompleteReadValueToken( buffer.Length );
 
             return value;
         }
@@ -587,7 +587,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( Double ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.Number, buffer.Length );
+            CompleteReadValueToken( buffer.Length );
 
             return value;
         }
@@ -630,7 +630,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( Decimal ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.Number, buffer.Length );
+            CompleteReadValueToken( buffer.Length );
 
             return value;
         }
@@ -689,7 +689,7 @@ namespace Maverick.Json
                 }
             }
 
-            CompleteReadToken( JsonToken.Boolean, value ? 4 : 5 );
+            CompleteReadValueToken( value ? 4 : 5 );
 
             return value;
         }
@@ -732,7 +732,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( TimeSpan ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.String, buffer.Length + 1 );
+            CompleteReadValueToken( buffer.Length + 1 );
 
             return value;
         }
@@ -775,7 +775,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( DateTime ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.String, buffer.Length + 1 );
+            CompleteReadValueToken( buffer.Length + 1 );
 
             return value;
         }
@@ -818,7 +818,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( DateTimeOffset ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.String, buffer.Length + 1 );
+            CompleteReadValueToken( buffer.Length + 1 );
 
             return value;
         }
@@ -861,7 +861,7 @@ namespace Maverick.Json
                 JsonSerializationException.ThrowInvalidValue( typeof( Guid ), UnescapeString( buffer, 0 ) );
             }
 
-            CompleteReadToken( JsonToken.String, buffer.Length + 1 );
+            CompleteReadValueToken( buffer.Length + 1 );
 
             return value;
         }
@@ -895,7 +895,7 @@ namespace Maverick.Json
                     throw new JsonSerializationException( "Detected invalid base64 string." );
                 }
 
-                CompleteReadToken( JsonToken.String, byteCount + 1 );
+                CompleteReadValueToken( byteCount + 1 );
 
                 return rentedBytes.AsSpan( 0, bytesWritten ).ToArray();
             }
@@ -1183,7 +1183,7 @@ namespace Maverick.Json
         }
 
 
-        private void CompleteReadToken( JsonToken token, Int32 bytesConsumed )
+        private void CompleteReadValueToken( Int32 bytesConsumed )
         {
             TryPopPropertyName();
 
@@ -1533,19 +1533,19 @@ namespace Maverick.Json
 
             if ( span.SequenceEqual( Constants.NaN ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.NaN.Length + 1 );
+                CompleteReadValueToken( Constants.NaN.Length + 1 );
 
                 return Single.NaN;
             }
             else if ( span.SequenceEqual( Constants.NegativeInfinity ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.NegativeInfinity.Length + 1 );
+                CompleteReadValueToken( Constants.NegativeInfinity.Length + 1 );
 
                 return Single.NegativeInfinity;
             }
             else if ( span.SequenceEqual( Constants.PositiveInfinity ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.PositiveInfinity.Length + 1 );
+                CompleteReadValueToken( Constants.PositiveInfinity.Length + 1 );
 
                 return Single.PositiveInfinity;
             }
@@ -1564,19 +1564,19 @@ namespace Maverick.Json
 
             if ( span.SequenceEqual( Constants.NaN ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.NaN.Length + 1 );
+                CompleteReadValueToken( Constants.NaN.Length + 1 );
 
                 return Double.NaN;
             }
             else if ( span.SequenceEqual( Constants.NegativeInfinity ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.NegativeInfinity.Length + 1 );
+                CompleteReadValueToken( Constants.NegativeInfinity.Length + 1 );
 
                 return Double.NegativeInfinity;
             }
             else if ( span.SequenceEqual( Constants.PositiveInfinity ) )
             {
-                CompleteReadToken( JsonToken.String, Constants.PositiveInfinity.Length + 1 );
+                CompleteReadValueToken( Constants.PositiveInfinity.Length + 1 );
 
                 return Double.PositiveInfinity;
             }

--- a/src/Maverick.Json.csproj
+++ b/src/Maverick.Json.csproj
@@ -5,7 +5,7 @@
         <Version>1.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-        <PackageVersion>1.0.2</PackageVersion>
+        <PackageVersion>1.0.3</PackageVersion>
         <PackageProjectUrl>https://github.com/zlatanov/json</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>json</PackageTags>

--- a/src/Serialization/JsonProperty`TOwner.cs
+++ b/src/Serialization/JsonProperty`TOwner.cs
@@ -30,6 +30,10 @@ namespace Maverick.Json.Serialization
                     mappedName = propertyAttribute.Name;
                 }
             }
+            else
+            {
+                SerializeNulls = parent.Settings.SerializeNulls;
+            }
 
             Name = mappedName;
             PropertyType = ReflectionHelpers.GetFieldOrPropertyType( member );

--- a/tests/CorrectnessTests.cs
+++ b/tests/CorrectnessTests.cs
@@ -640,8 +640,6 @@ line 2",
 
             Assert.Equal( expected, actual );
 
-            var xx = NJ.JsonConvert.DeserializeObject<T>( actual );
-
             // Test deserialization
             var deserialziedObj = JsonConvert.Deserialize<T>( actual );
             var deserializedObjJson = JsonConvert.Serialize( deserialziedObj );

--- a/tests/JsonIgnoreTests.cs
+++ b/tests/JsonIgnoreTests.cs
@@ -42,11 +42,16 @@ namespace Maverick.Json
 
         private sealed class TestObject
         {
-            [JsonIgnore]
+            [CustomJsonIgnore]
             public String Name { get; set; }
 
 
             public Int32 Age { get; set; }
+        }
+
+
+        private sealed class CustomJsonIgnoreAttribute : JsonIgnoreAttribute
+        {
         }
     }
 }

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -175,6 +175,37 @@ namespace Maverick.Json
         }
 
 
+        [Fact]
+        public void Skip()
+        {
+            var json = JsonConvert.Serialize( new
+            {
+                Name = "Not a Random String",
+                Age = 22,
+                Enabled = true,
+                Null = default( Int32? ),
+                Array = new Object[] { "String", 0.0, true },
+                Addresses = new
+                {
+                    Country = new
+                    {
+                        Name = "France"
+                    }
+                }
+            }, settings: new JsonSettings
+            {
+                Format = JsonFormat.Indented,
+                SerializeNulls = true
+            } );
+            var reader = CreateReader( json );
+
+            // The skip should ignore the entire json
+            reader.Skip();
+
+            Assert.Equal( JsonToken.None, reader.Peek() );
+        }
+
+
         private static JsonReader CreateReader( String json )
         {
             var bytes = Encoding.UTF8.GetBytes( json );

--- a/tests/JsonWriterTests.cs
+++ b/tests/JsonWriterTests.cs
@@ -86,7 +86,7 @@ namespace Maverick.Json
         [Fact]
         public void ByteArrayShouldNotInfiniteLoop()
         {
-            var data = new Byte[ 10000 ];
+            var data = new Byte[10000];
 
             using ( var rng = new RNGCryptoServiceProvider() )
             {
@@ -97,6 +97,28 @@ namespace Maverick.Json
             var base64 = Convert.ToBase64String( data );
 
             Assert.Equal( "\"" + base64 + "\"", json );
+        }
+
+
+        [Fact]
+        public void DelegateShouldNotBeSerialized()
+        {
+            var json = JsonConvert.Serialize( new
+            {
+                Delegate = new Func<String>( () => "Should Not Be Serialized" )
+            } );
+
+            Assert.Equal( "{}", json );
+        }
+
+
+        [Fact]
+        public void SpanShouldNotBeSerialized()
+        {
+            var memory = new Memory<Byte>( new Byte[1] { 1 } );
+            var json = JsonConvert.Serialize( memory );
+
+            Assert.Equal( "{\"Length\":1,\"IsEmpty\":false}", json );
         }
 
 


### PR DESCRIPTION
The goals here are:

- [x] Reduce the number of calls to Advance()
- [ ] Add more unit tests to make sure we don't break anything
- [ ] Add more performance tests for different scenarios
- [ ] Measure memory allocations and make sure we allocate as little as possible besides what's needed for the deserialized objects
- [ ] Better exceptions when the JSON is invalid